### PR TITLE
Fixed auth parameter validation

### DIFF
--- a/DracoonSdk/SdkPublic/DracoonAuth.cs
+++ b/DracoonSdk/SdkPublic/DracoonAuth.cs
@@ -61,8 +61,10 @@ namespace Dracoon.Sdk {
         }
 
         private static void ValidateParameters(string name, string value, bool nullable = false) {
-            if (value == null && !nullable) {
-                throw new ArgumentNullException(name);
+            if (value == null) {
+                if (!nullable)
+                    throw new ArgumentNullException(name);
+                return;
             }
 
             if (string.IsNullOrWhiteSpace(value)) {


### PR DESCRIPTION
Fixed auth parameter validation if refreshToken is null

Repro Steps: 
Construct DracoonAuth with valid access token and refresh token set to null (throws validation exception).

`new DracoonAuth(_clientId, _clientSecret, _accessToken, null);`